### PR TITLE
Fix for TYPO3 10.4 and PHP 7.4

### DIFF
--- a/Classes/Override/LocalizationController.php
+++ b/Classes/Override/LocalizationController.php
@@ -185,7 +185,7 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
 
         return (new JsonResponse())->setPayload([
             'records' => $records,
-            'columns' => $this->getPageColumns($pageId),
+            'columns' => $this->getPageColumns($pageId,[],[]),
         ]);
     }
 


### PR DESCRIPTION
Too few arguments to function TYPO3\CMS\Backend\Controller\Page\LocalizationController::getPageColumns(), 1 passed in